### PR TITLE
fill Pointer and iPointer in black

### DIFF
--- a/ASCIIToSVG.php
+++ b/ASCIIToSVG.php
@@ -1304,6 +1304,7 @@ class ASCIIToSVG {
       viewBox="0 0 10 10" refX="5" refY="5" 
       markerUnits="strokeWidth"
       markerWidth="8" markerHeight="7"
+      fill="black"
       orient="auto">
       <path d="M 10 0 L 10 10 L 0 5 z" />
     </marker>
@@ -1311,6 +1312,7 @@ class ASCIIToSVG {
       viewBox="0 0 10 10" refX="5" refY="5" 
       markerUnits="strokeWidth"
       markerWidth="8" markerHeight="7"
+      fill="black"
       orient="auto">
       <path d="M 0 0 L 10 5 L 0 10 z" />
     </marker>


### PR DESCRIPTION
When the svg file is imported in some software, libreoffice for example, but some other too,
the arrowhead don't appear, they are transparent. By adding a fill="black" to the (i)Pointer
defs, arrowheads are correctly drawn.

![image](https://cloud.githubusercontent.com/assets/1008292/24497023/553113ce-153a-11e7-86d7-9eff1efc5985.png)
