### PR TITLE
add missing L commands in document.path

### DIFF
--- a/objects/document.path
+++ b/objects/document.path
@@ -1,1 +1,1 @@
-<path width="100" height="100" d="M 0 100 25 115 75 85 100 100 V 0 H 0 Z" />
+<path width="100" height="100" d="M 0 100 L 25 115 L 75 85 L 100 100 V 0 H 0 Z" />


### PR DESCRIPTION
Hi again.
I tried to draw objects. document.path was surprising. It turns out the file is better
rendered with additional "L" SVG commands, although SVG doesn't require them.
I'm not sure this is not a bug somewhere in the code that reads the .path files, but this is
a quick fix...

The initial document.path is not completely scaled/offset in the final document. the `75 85 100 100` coordinates are not transformed, as the others are :

    <path id="pathd" d="M 4.5 248 L 18 255.2 75 85 100 100 V 200 H 4.5 Z " filter="url(#dsFilter)" fill="#fff"  />
And these are the coordinates when using multiple L commands :

    <path id="pathd" d="M 4.5 248 L 18 255.2 L 45 240.8 L 58.5 248 V 200 H 4.5 Z " filter="url(#dsFilter)" fill="#fff"  />
![capture du 2017-04-01 16-16-27](https://cloud.githubusercontent.com/assets/1008292/24579588/a6038128-16f8-11e7-8ad5-20c9f29fd279.png)

    .-----.
    |[c]  |
    |     |
    '--+--'
       |
       v
    .-----.
    |[s]  |
    |     |
    '--+--'
       |
       v
    .-----.
    |[d]  |
    |     |
    '-----'
     
    [c]: {"a2s:type":"computer","a2s:delref":true}
    [s]: {"a2s:type":"storage","a2s:delref":true}
    [d]: {"a2s:type":"document","a2s:delref":true}
    
