### PR TITLE
fix substitution order for & and <

### DIFF
--- a/ASCIIToSVG.php
+++ b/ASCIIToSVG.php
@@ -1143,8 +1143,8 @@ class SVGText {
      *
      * We want to replace these in text without confusing SVG.
      */
-    $s = array('<', '>', '&');
-    $r = array('&lt;', '&gt;', '&amp;');
+    $s = array('&','<', '>');
+    $r = array('&amp;', '&lt;', '&gt;');
     return str_replace($s, $r, $str);
   }
 


### PR DESCRIPTION
Hi,
When substituting ``<``, ``>`` and ``&`` with their corresponding xmlentities ``&lt;``, ``&gt;`` and ``&amp;``, order matters. The ``&`` substitution must come first, otherwise it will replace the ``&`` from ``&lt;`` or ``&gt;`` and we end up with ``&amp;lt;``...

![image](https://user-images.githubusercontent.com/1008292/28648837-fe5ca2f4-7270-11e7-8600-4f6304d01d86.png)

This simple patch fixes the replace order.