### PR TITLE
Fix parsing of -s parameter

### DIFF
--- a/a2s
+++ b/a2s
@@ -2,7 +2,7 @@
 <?php # vim:ts=2:sw=2:et:ft=php
 /*
  * a2s: CLI utility for ASCIIToSVG
- * Copyright © 2012 Devon H. O'Dell <devon.odell@gmail.com>
+ * Copyright Â© 2012 Devon H. O'Dell <devon.odell@gmail.com>
  * All rights reserved.
  * 
  * Redistribution and use in source and binary forms, with or without
@@ -99,7 +99,7 @@ if (isset($opts['o'])) {
 if (isset($opts['s'])) {
   $scale = explode(',', $opts['s']);
   if (count($scale) != 2 || !is_numeric($scale[0]) || 
-      is_numeric($scale[1])) {
+      !is_numeric($scale[1])) {
     echo "Invalid scaling factor \"{$scale[0]},{$scale[1]}\"\n";
     exit(1);
   }


### PR DESCRIPTION
There's a missing `!` in the handling of the `-s` parameter.

Not sure why the copyright string change is showing up. I think this was caused by GitHubs ISO-8859-1 to UTF-8 conversion.