### PR TITLE
Fix translation order in rotation about (x,y)

### DIFF
--- a/ASCIIToSVG.php
+++ b/ASCIIToSVG.php
@@ -599,7 +599,7 @@ class SVGPath {
   private function rotateTransform($angle, $x, $y, $cX = 0, $cY = 0) {
     $angle = $angle * (pi() / 180);
     if ($cX != 0 || $cY != 0) {
-      list ($x, $y) = $this->translateTransform($cX, $cY, $x, $y);
+      list ($x, $y) = $this->translateTransform(-$cX, -$cY, $x, $y);
     }
 
     $matrix = array(array(cos($angle), -sin($angle), 0),
@@ -608,7 +608,7 @@ class SVGPath {
     $ret = $this->matrixTransform($matrix, $x, $y);
 
     if ($cX != 0 || $cY != 0) {
-      list ($x, $y) = $this->translateTransform(-$cX, -$cY, $ret[0], $ret[1]);
+      list ($x, $y) = $this->translateTransform($cX, $cY, $ret[0], $ret[1]);
       $ret[0] = $x;
       $ret[1] = $y;
     }

--- a/a2s52.php
+++ b/a2s52.php
@@ -599,7 +599,7 @@ class A2S_SVGPath {
   private function rotateTransform($angle, $x, $y, $cX = 0, $cY = 0) {
     $angle = $angle * (pi() / 180);
     if ($cX != 0 || $cY != 0) {
-      list ($x, $y) = $this->translateTransform($cX, $cY, $x, $y);
+      list ($x, $y) = $this->translateTransform(-$cX, -$cY, $x, $y);
     }
 
     $matrix = array(array(cos($angle), -sin($angle), 0),
@@ -608,7 +608,7 @@ class A2S_SVGPath {
     $ret = $this->matrixTransform($matrix, $x, $y);
 
     if ($cX != 0 || $cY != 0) {
-      list ($x, $y) = $this->translateTransform(-$cX, -$cY, $ret[0], $ret[1]);
+      list ($x, $y) = $this->translateTransform($cX, $cY, $ret[0], $ret[1]);
       $ret[0] = $x;
       $ret[1] = $y;
     }


### PR DESCRIPTION
Hi,
There was a small error in `private function rotateTransform`. When rotating about (x,y), the correct transformation order is 
- translate(-x, -y)
- rotate()
- translate(x, y)

Translation order was reversed. See https://math.stackexchange.com/a/2093322 for example.
